### PR TITLE
Modify send_message_to_model to take advantage of conversation history

### DIFF
--- a/app.py
+++ b/app.py
@@ -41,12 +41,17 @@ model = genai.GenerativeModel(
 chat_session = model.start_chat(history=[])
 
 # Function to send a message to the model
-def send_message_to_model(message, image_path):
-    image_input = {
-        'mime_type': 'image/jpeg',
-        'data': pathlib.Path(image_path).read_bytes()
-    }
-    response = chat_session.send_message([message, image_input])
+def send_message_to_model(message, image_path=None):
+    if image_path is not None:
+        
+        image_input = {
+            'mime_type': 'image/jpeg',
+            'data': pathlib.Path(image_path).read_bytes()
+        }
+        response = chat_session.send_message([message, image_input])
+    else:
+        
+        response = chat_session.send_message([message])
     return response.text
 
 # Streamlit app
@@ -80,19 +85,19 @@ def main():
                 # Refine the description
                 st.write("🔍 Refining description with visual comparison...")
                 refine_prompt = f"Compare the described UI elements with the provided image and identify any missing elements or inaccuracies. Also Describe the color of the elements. Provide a refined and accurate description of the UI elements based on this comparison. Here is the initial description: {description}"
-                refined_description = send_message_to_model(refine_prompt, temp_image_path)
+                refined_description = send_message_to_model(refine_prompt)
                 st.write(refined_description)
 
                 # Generate HTML
                 st.write("🛠️ Generating website...")
                 html_prompt = f"Create an HTML file based on the following UI description, using the UI elements described in the previous response. Include {framework} CSS within the HTML file to style the elements. Make sure the colors used are the same as the original UI. The UI needs to be responsive and mobile-first, matching the original UI as closely as possible. Do not include any explanations or comments. Avoid using ```html. and ``` at the end. ONLY return the HTML code with inline CSS. Here is the refined description: {refined_description}"
-                initial_html = send_message_to_model(html_prompt, temp_image_path)
+                initial_html = send_message_to_model(html_prompt)
                 st.code(initial_html, language='html')
 
                 # Refine HTML
                 st.write("🔧 Refining website...")
                 refine_html_prompt = f"Validate the following HTML code based on the UI description and image and provide a refined version of the HTML code with {framework} CSS that improves accuracy, responsiveness, and adherence to the original design. ONLY return the refined HTML code with inline CSS. Avoid using ```html. and ``` at the end. Here is the initial HTML: {initial_html}"
-                refined_html = send_message_to_model(refine_html_prompt, temp_image_path)
+                refined_html = send_message_to_model(refine_html_prompt)
                 st.code(refined_html, language='html')
 
                 # Save the refined HTML to a file


### PR DESCRIPTION
Hi,

I am working on something similar and noticed that in your code, you are re-sending the image with each request. I suggest taking advantage of the conversation history and sending the image only on the first request. In this pull request, I modified the send_message_to_model function to handle an optional image_path parameter and utilize the image in the chat history for the other requests. With this approach, the image is sent just at the beginning, simplifying the code and, in theory, improving response speed.

Let me know if you have considered this approach and if you think it is a viable solution.